### PR TITLE
Mention force option in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ gulp.task('default', function () {
 You can also specify the `base` as one of the options. Again, you don't need to
 do this if you've given it to `rev.manifest()`!
 
+You can also add `force: true` as an option. This is passed through to the underlying [del](https://github.com/sindresorhus/del#optionsforce) plugin which accepts it to allow deletion outside the current working directory. This comes in handy when you get a gulp error like 'Cannot delete files/folders outside the current working directory. Can be overriden with the `force` option.'
+
 ## License
 
 Released under the MIT license.


### PR DESCRIPTION
I think it could help some users to note in your readme that del's {force: true} option can be used with your plugin too. 

It solved an issue I was having because I was working outside the current Gulp working directory. I read about that force option for the del plugin, but wouldn't expect it to work with yours too. Gave it a shot, worked like magic! This might be obvious for experienced users, but it wasn't for me. So let's add it in there, and save some people some time.
