### PR TITLE
Add default for options.oldManifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function revDel(options, cb) {
 	// Useful when testing
 	options.delFn = options.delFn || del;
 	options.dest = options.dest || '.';
+	options.oldManifest = options.oldManifest || path.join(options.dest, 'rev-manifest.json');
 
 	options.suppress = (options.suppress !== false);
 

--- a/index.js
+++ b/index.js
@@ -14,11 +14,12 @@ function revDel(options, cb) {
 	// Useful when testing
 	options.delFn = options.delFn || del;
 	options.dest = options.dest || '.';
-	options.oldManifest = options.oldManifest || path.join(options.dest, 'rev-manifest.json');
 
 	options.suppress = (options.suppress !== false);
 
 	if (options.newManifest) {
+		options.oldManifest = options.oldManifest || path.join(options.dest, 'rev-manifest.json');
+
 		var oldManifest = getManifest(options.oldManifest, options.suppress);
 		var newManifest = getManifest(options.newManifest);
 		var oldFiles = getChanged(oldManifest, newManifest);


### PR DESCRIPTION
I was experiencing the "Files not deleting" issue and traced the problem to an undefined `options.oldManifest`. Adding this default value does the trick for me.
