### PR TITLE
Fixes path resolution in tests on windows

### DIFF
--- a/test.js
+++ b/test.js
@@ -120,7 +120,7 @@ it('should accept dest', function (cb) {
 
 	stream.on('data', function (file) {
 		file.revDeleted.length.should.equal(2);
-		file.revDeleted.should.eql(['test/foo-abc.js', 'test/world']);
+		file.revDeleted.should.eql([path.normalize('test/foo-abc.js'), path.normalize('test/world')]);
 
 		cb();
 	});


### PR DESCRIPTION
When running tests on windows, the test `should accept dest` fails due to path resolution:

```
AssertionError: expected [ 'test\\foo-abc.js', 'test\\world' ] to equal [ 'test/foo-abc.js', 'test/world' ] (at '0', A has 'test\\foo-abc.js' and B has 'test/foo-abc.js')
```

Because path separator on windows is `\\` and not `/`

Reference: [Tips for Writing Portable Node.js Code](https://gist.github.com/domenic/2790533)
