### PR TITLE
increase lodash dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/callumacrae/rev-del",
   "dependencies": {
     "del": "^1.1.1",
-    "lodash": "^3.1.0",
+    "lodash": ">=3.1 <5",
     "mocha": "^2.1.0",
     "should": "^4.6.5",
     "through2": "^0.6.3"


### PR DESCRIPTION
Lodash v3 is no longer supported, and it looks like v4 does not introduce any breaking changes for this package.

Can we increase the range of the supported lodash dependency to include v4 as proposed in this PR?

This would avoid unmet peer dependency warnings on npm install when using a supported version of lodash.
